### PR TITLE
Add Local DNS Record & Note to update_clients.py; Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ UniFi Client Manager is a Python project that provides a set of scripts to autom
 ### Obtaining Cookie/Tokens for `.env` (Google Chrome)
 1. Login to the local interface for your UDM/UniFi Network console (not Cloud/Remote Access). 
 2. Right Click -> Inspect. 
-3. Choose the `Network` tab, then pick a resource (`device` or `client` work). 
-4. Within `Headers` sub-tab, copy the string listed within the `Cookie:` header that begins with `TOKEN=` (include this prefix) until the string ends in a semicolon `;` (not including the semicolon). Paste this value as your `SESSION_COOKIE` in the `.env` file.
+3. Choose the `Network` tab, refresh the page, then pick a resource that has both of the required values below (`device`, `info`, and a few others work).
+4. Within `Headers` sub-tab, copy the string listed within the `Cookie:` header that begins with `TOKEN=` (include this prefix) until the location it ends in a semicolon `;` (not including the semicolon). Paste this value as your `SESSION_COOKIE` in the `.env` file.
 5. At the bottom of `Headers`, copy the entire string listed within `X-Csrf-Token:` and paste this value as your `CSRF_TOKEN` value in the `.env` file.
 6. `UDM_SITE` refers to the site name within the UniFi Network application running on your console, not the console name. The site name is in the local URL, for example `https://<host_or_ip>/network/<site>/dashboard`. For most installations without a multi-site setup within the Network application this will likely be `default`.
 

--- a/README.md
+++ b/README.md
@@ -24,14 +24,21 @@ UniFi Client Manager is a Python project that provides a set of scripts to autom
     ```bash
     cd unifi-client-manager
     ```
+3. Initialize a Python Virtual Environment (Optional):
+    ```bash
+    python -m venv .
+    source ./bin/activate
+    ```
 
-3. Install the required Python packages:
+    Follow your python distribution or OS-recommended method for installing the `venv` module if not already available, or skip this step.
+
+4. Install the required Python packages:
 
     ```bash
     pip install -r requirements.txt
     ```
 
-4. Create a `.env` file in the project directory and provide the following information:
+5. Create a `.env` file in the project directory and provide the following information:
 
     ```env
     UDM_URL=https://your-udm-se-url
@@ -40,7 +47,15 @@ UniFi Client Manager is a Python project that provides a set of scripts to autom
     SESSION_COOKIE=your-session-cookie
     ```
 
-    Replace `your-udm-se-url`, `your-site-name`, `your-csrf-token`, and `your-session-cookie` with the actual values obtained from your UDM SE setup. The cookie and csrf are both easily captured by logging into your UDM and copying the cookie and csrf token from the browser. This will only work for the session time of the cookie.
+    Replace `your-udm-se-url`, `your-site-name`, `your-csrf-token`, and `your-session-cookie` with the actual values obtained from your UDM SE setup (see below for an example). The cookie and csrf are both easily captured by logging into your UDM and copying the cookie and csrf token from the browser. This will only work for the session time of the cookie.
+
+### Obtaining Cookie/Tokens for `.env` (Google Chrome)
+1. Login to the local interface for your UDM/UniFi Network console (not Cloud/Remote Access). 
+2. Right Click -> Inspect. 
+3. Choose the `Network` tab, then pick a resource (`device` or `client` work). 
+4. Within `Headers` sub-tab, copy the string listed within the `Cookie:` header that begins with `TOKEN=` (include this prefix) until the string ends in a semicolon `;` (not including the semicolon). Paste this value as your `SESSION_COOKIE` in the `.env` file.
+5. At the bottom of `Headers`, copy the entire string listed within `X-Csrf-Token:` and paste this value as your `CSRF_TOKEN` value in the `.env` file.
+6. `UDM_SITE` refers to the site name within the UniFi Network application running on your console, not the console name. The site name is in the local URL, for example `https://<host_or_ip>/network/<site>/dashboard`. For most installations without a multi-site setup within the Network application this will likely be `default`.
 
 ## Usage
 
@@ -50,6 +65,8 @@ UniFi Client Manager is a Python project that provides a set of scripts to autom
     - `mac_address`: The MAC address of the client device.
     - `name`: The desired name for the client device.
     - `fixed_ip` (optional): The fixed IP address to assign to the client device.
+    - `local_dns` (optional): The local DNS record to assign to the client device.
+    - `note` (optional): The note to assign to the client device.
 
     Place the CSV file in the `data` directory.
 

--- a/update_clients.py
+++ b/update_clients.py
@@ -45,6 +45,8 @@ with open(csv_file_path, "r") as csv_file:
         mac_address = row["mac_address"]
         name = row["name"]
         fixed_ip = row.get("fixed_ip")  # Optional fixed IP address
+        local_dns = row.get("local_dns") # Optional local DNS record
+        note = row.get("note") # Optional Note
 
         # Check if client exists
         client = next((c for c in existing_clients if c["mac"] == mac_address), None)
@@ -55,7 +57,11 @@ with open(csv_file_path, "r") as csv_file:
             update_data = {
                 "name": name,
                 "use_fixedip": bool(fixed_ip),
-                "fixed_ip": fixed_ip if fixed_ip else ""
+                "fixed_ip": fixed_ip if fixed_ip else "",
+                "local_dns_record_enabled": bool(local_dns),
+                "local_dns_record": local_dns if local_dns else "",
+                "noted": bool(note),
+                "note": note if note else ""
             }
             response = session.put(update_url, json=update_data, verify=False)
             response.raise_for_status()
@@ -67,7 +73,10 @@ with open(csv_file_path, "r") as csv_file:
                 "name": name,
                 "use_fixedip": bool(fixed_ip),
                 "fixed_ip": fixed_ip if fixed_ip else "",
-                "local_dns_record_enabled": False
+                "local_dns_record_enabled": bool(local_dns),
+                "local_dns_record": local_dns if local_dns else "",
+                "noted": bool(note),
+                "note": note if note else ""
             }
             response = session.post(create_url, json=create_data, verify=False)
             response.raise_for_status()


### PR DESCRIPTION
- Add `local_dns` and `note` options to `update_clients.py` to support bulk creation/updating of clients including Local DNS Records and Notes values.
- Update README.md to include an optional step/example of installing requirements and running the script within a Python venv.
- Update README.md to add descriptive instructions for obtaining session tokens/cookie from UniFi console using Google Chrome.
- Update README.md to provide example of `local_dns` and `note` columns in `client_list.csv` preparation for `update_clients.py`.

Successfully migrated my client info for around 200 nodes including fixed IPs, local DNS records, and notes from a UDMSE to EFG (script works without modifications on EFG).

Thanks for sharing a great project.